### PR TITLE
Update canonical from `v0.5` to `v0.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update canonical from `v0.5` to `v0.6` [#14](https://github.com/dusk-network/dusk-kelvin-map/issues/14)
+- Deprecate the crate in favor of `dusk-hamt`
 
 ## [0.3.0] - 25-01-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update canonical from `v0.5` to `v0.6` [#14](https://github.com/dusk-network/dusk-kelvin-map/issues/14)
+
 ## [0.3.0] - 25-01-21
 ### Changed
 - Create an internal `_remove` method, which does not call to `balance`, avoiding unnecessary recursion.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,10 @@ license = "MPL-2.0"
 categories = ["data-structures", "embedded", "no-std", "wasm"]
 
 [dependencies]
-microkelvin = "0.6"
-canonical = "0.5"
-canonical_derive = "0.5"
+microkelvin = "0.7"
+canonical = "0.6"
+canonical_derive = "0.6"
 
 [dev-dependencies]
-canonical_host = "0.5"
-rand = "0.7"
+rand = "0.8"
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ This implementation uses Microkelvin as backend and is optimized to work under c
 ## Example
 
 ```rust
-use canonical_host::MemStore;
 use dusk_kelvin_map::Map;
 
 // Create a new map u64 -> u32 that will use MemStore as storage backend.
-let mut map: Map<u64, u32, MemStore> = Map::default();
+let mut map: Map<u64, u32> = Map::default();
 
 // Insert a new mapping 2 -> 4
 map.insert(2, 4).expect("Failed to insert data.");

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Dusk Kelvin Map
 
+#### NOTE: This crate is deprecated in favor of [dusk-hamt](https://crates.io/crates/dusk-hamt)
+
 Binary search tree implementation with no associated value on the nodes.
 
 It will extend the standard properties of a default BST.

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -7,8 +7,8 @@
 use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
-use canonical::Canon;
 use canonical_derive::Canon;
+use microkelvin::Keyed;
 
 #[derive(Debug, Clone, Canon)]
 /// Wrapper for the key -> value mapping the will act as leaf of the tree
@@ -25,8 +25,8 @@ where
         Self { key, value }
     }
 
-    /// Stored key of the key -> value mapping
-    pub fn key(&self) -> &K {
+    /// Stored key of the key -> value mapping as concrete representation
+    pub(crate) fn _key(&self) -> &K {
         &self.key
     }
 
@@ -38,6 +38,15 @@ where
     /// Mutable reference to the stored value of the key -> value mapping
     pub fn value_mut(&mut self) -> &mut V {
         &mut self.value
+    }
+}
+
+impl<K, V> Keyed<K> for Leaf<K, V>
+where
+    K: Ord,
+{
+    fn key(&self) -> &K {
+        &self.key
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
 #![warn(missing_docs)]
+#![feature(ordering_helpers)]
 
 pub use annotation::{MapAnnotation, MapAnnotationDefault};
 pub use leaf::Leaf;
@@ -17,8 +18,5 @@ mod annotation;
 mod leaf;
 mod map;
 
-#[cfg(test)]
-mod tests;
-
 /// [`KelvinMap`] default implementation using the minimal [`MapAnnotation`]
-pub type Map<K, V, S> = KelvinMap<K, V, MapAnnotationDefault<K, S>, S>;
+pub type Map<K, V> = KelvinMap<K, V, MapAnnotationDefault<K>>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -4,17 +4,17 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::Leaf;
+use crate::{Leaf, MapAnnotation};
 
-use core::borrow::Borrow;
-use core::mem;
 use core::ops::{Deref, DerefMut};
+use core::{cmp, mem};
 
-use canonical::{Canon, InvalidEncoding, Store};
+use canonical::{Canon, CanonError};
 use canonical_derive::Canon;
+
 use microkelvin::{
-    Annotated, Annotation, Branch, BranchMut, Cardinality, Child, ChildMut,
-    Compound, Max, Step, StepMut, Walk, WalkMut,
+    Annotated, Branch, BranchMut, Cardinality, Child, ChildMut, Compound,
+    MaxKey, Step, Walk, Walker,
 };
 
 #[derive(Debug, Clone, Canon)]
@@ -22,12 +22,11 @@ use microkelvin::{
 ///
 /// The borrowed [`Max`] from the annotation will be used to traverse the tree and is expected to
 /// be the maximum `K` contained in that sub-tree.
-pub enum KelvinMap<K, V, A, S>
+pub enum KelvinMap<K, V, A>
 where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S>,
-    S: Store,
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
 {
     /// Represents and empty endpoint
     Empty,
@@ -36,34 +35,31 @@ where
     /// Annotated node that will contain, at least, the maximum key value that exists within this
     /// sub-tree
     Node(
-        Annotated<KelvinMap<K, V, A, S>, S>,
-        Annotated<KelvinMap<K, V, A, S>, S>,
+        Annotated<KelvinMap<K, V, A>, A>,
+        Annotated<KelvinMap<K, V, A>, A>,
     ),
 }
 
-impl<K, V, A, S> Default for KelvinMap<K, V, A, S>
+impl<K, V, A> Default for KelvinMap<K, V, A>
 where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S>,
-    S: Store,
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
 {
     fn default() -> Self {
         KelvinMap::Empty
     }
 }
 
-impl<K, V, A, S> Compound<S> for KelvinMap<K, V, A, S>
+impl<K, V, A> Compound<A> for KelvinMap<K, V, A>
 where
-    V: Canon<S>,
-    K: Canon<S> + Ord,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S>,
-    S: Store,
+    V: Canon,
+    K: Canon + Ord,
+    A: MapAnnotation<K, V>,
 {
     type Leaf = Leaf<K, V>;
-    type Annotation = A;
 
-    fn child(&self, ofs: usize) -> Child<Self, S> {
+    fn child(&self, ofs: usize) -> Child<Self, A> {
         match (ofs, self) {
             (0, KelvinMap::Node(l, _)) => Child::Node(l),
             (1, KelvinMap::Node(_, r)) => Child::Node(r),
@@ -72,7 +68,7 @@ where
         }
     }
 
-    fn child_mut(&mut self, ofs: usize) -> ChildMut<Self, S> {
+    fn child_mut(&mut self, ofs: usize) -> ChildMut<Self, A> {
         match (ofs, self) {
             (0, KelvinMap::Node(l, _)) => ChildMut::Node(l),
             (1, KelvinMap::Node(_, r)) => ChildMut::Node(r),
@@ -82,22 +78,135 @@ where
     }
 }
 
-#[inline]
-fn borrow_max<K, A: Borrow<Max<K>>>(ann: &A) -> &Max<K> {
-    // Borrow does not accept generic parameters; this is a helper to relax the type resolution of
-    // the compiler
-    ann.borrow()
+// MaxKey doesn't implement PartialCmp<K>
+fn cmp_max_key<K, V, A>(
+    ann: &Annotated<KelvinMap<K, V, A>, A>,
+    key: &K,
+) -> cmp::Ordering
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
+{
+    match ann.annotation().borrow() {
+        MaxKey::Maximum(ann) => MaxKey::Maximum(ann).cmp(&MaxKey::Maximum(key)),
+        MaxKey::NegativeInfinity => cmp::Ordering::Less,
+    }
 }
 
-impl<K, V, A, S> KelvinMap<K, V, A, S>
+struct BinaryWalker<'a, K>(&'a K)
 where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S>
-        + Annotation<KelvinMap<K, V, A, S>, S>
-        + Borrow<Cardinality>
-        + Borrow<Max<K>>,
-    S: Store,
+    K: Canon + Ord;
+
+impl<'a, K, V, A> Walker<KelvinMap<K, V, A>, A> for BinaryWalker<'a, K>
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
+{
+    fn walk(&mut self, walk: Walk<KelvinMap<K, V, A>, A>) -> Step {
+        match (walk.child(0), walk.child(1)) {
+            // (0, 0) Empty tree
+            (
+                Child::EndOfNode | Child::Empty,
+                Child::EndOfNode | Child::Empty,
+            ) => Step::Abort,
+
+            // (0, r) Invalid tree
+            (
+                Child::EndOfNode | Child::Empty,
+                Child::Leaf(_) | Child::Node(_),
+            ) => unreachable!(),
+
+            // (_, r), r < k Key out of range
+            (_, Child::Node(r)) if cmp_max_key(r, &self.0).is_lt() => {
+                Step::Abort
+            }
+
+            // Key match
+            (Child::Leaf(l), _) if l._key() == self.0 => Step::Found(0),
+            (_, Child::Leaf(r)) if r._key() == self.0 => Step::Found(1),
+
+            // End of path without match
+            (
+                Child::Leaf(_),
+                Child::Leaf(_) | Child::EndOfNode | Child::Empty,
+            ) => Step::Abort,
+
+            // (l, _) l >= k Traverse left
+            (Child::Node(l), _) if cmp_max_key(l, &self.0).is_ge() => {
+                Step::Into(0)
+            }
+
+            // (_, r) Traverse right, k <= r is already tested
+            (_, Child::Node(_)) => Step::Into(1),
+
+            (
+                Child::Node(_),
+                Child::Empty | Child::EndOfNode | Child::Leaf(_),
+            ) => Step::Abort,
+        }
+    }
+}
+
+/// Private struct used to hide the complex branch signature behind an
+/// `impl Deref<Target = V>` for returning references to values in the map
+struct ValRef<'a, K, V, A>(Branch<'a, KelvinMap<K, V, A>, A>)
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>;
+
+impl<'a, K, V, A> Deref for ValRef<'a, K, V, A>
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
+{
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &**self.0
+    }
+}
+
+/// Private struct used to hide the complex branch signature behind an
+/// `impl DerefMut<Target = V>` for returning mutable references to values in the map
+struct ValRefMut<'a, K, V, A>(BranchMut<'a, KelvinMap<K, V, A>, A>)
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>;
+
+impl<'a, K, V, A> Deref for ValRefMut<'a, K, V, A>
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
+{
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &**self.0
+    }
+}
+
+impl<'a, K, V, A> DerefMut for ValRefMut<'a, K, V, A>
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut **self.0
+    }
+}
+
+impl<K, V, A> KelvinMap<K, V, A>
+where
+    K: Canon + Ord,
+    V: Canon,
+    A: MapAnnotation<K, V>,
 {
     /// Returns the number of elements in the map.
     pub fn len(&self) -> usize {
@@ -132,24 +241,9 @@ where
     pub fn get<'a>(
         &'a self,
         k: &K,
-    ) -> Result<Option<impl Deref<Target = V> + 'a>, S::Error> {
-        Branch::<'a, _, _>::walk(self, |f| match f {
-            Walk::Leaf(l) => {
-                if l.key() == k {
-                    Step::Found(l)
-                } else {
-                    Step::Next
-                }
-            }
-            Walk::Node(n) => {
-                if borrow_max(n.annotation()) >= k {
-                    Step::Into(n)
-                } else {
-                    Step::Next
-                }
-            }
-        })
-        .map(|result| result.map(|branch| ValRef(branch)))
+    ) -> Result<Option<impl Deref<Target = V> + 'a>, CanonError> {
+        Branch::walk(self, BinaryWalker(k))
+            .map(|result| result.map(|branch| ValRef(branch)))
     }
 
     /// Returns a mutable reference to the value corresponding to the key
@@ -158,38 +252,22 @@ where
     pub fn get_mut<'a>(
         &'a mut self,
         k: &K,
-    ) -> Result<Option<impl DerefMut<Target = V> + 'a>, S::Error> {
-        BranchMut::<'a, _, _>::walk(self, |f| match f {
-            WalkMut::Leaf(l) => {
-                if l.key() == k {
-                    StepMut::Found(l)
-                } else {
-                    StepMut::Next
-                }
-            }
-            WalkMut::Node(n) => {
-                if borrow_max(n.annotation()) >= k {
-                    StepMut::Into(n)
-                } else {
-                    StepMut::Next
-                }
-            }
-        })
-        .map(|result| result.map(|branch| ValRefMut(branch)))
+    ) -> Result<Option<impl DerefMut<Target = V> + 'a>, CanonError> {
+        BranchMut::walk(self, BinaryWalker(k))
+            .map(|result| result.map(|branch| ValRefMut(branch)))
     }
 
     /// Traverse the tree to find the minimum leaf-key
-    fn min_key_leaf(&self) -> Result<Option<Leaf<K, V>>, S::Error> {
+    fn min_key_leaf(&self) -> Result<Option<Leaf<K, V>>, CanonError> {
         match self {
             KelvinMap::Empty => Ok(None),
             KelvinMap::Leaf(l) => Ok(Some(l.clone())),
-
             KelvinMap::Node(l, _) => l.val()?.min_key_leaf(),
         }
     }
 
     /// Traverse the tree to find the maximum leaf-key
-    fn max_key_leaf(&self) -> Result<Option<Leaf<K, V>>, S::Error> {
+    fn max_key_leaf(&self) -> Result<Option<Leaf<K, V>>, CanonError> {
         match self {
             KelvinMap::Empty => Ok(None),
             KelvinMap::Leaf(l) => Ok(Some(l.clone())),
@@ -198,7 +276,7 @@ where
     }
 
     /// Balance the map
-    fn balance(&mut self) -> Result<(), S::Error> {
+    fn balance(&mut self) -> Result<(), CanonError> {
         let (l, r) = match self {
             KelvinMap::Node(l, r) => (l, r),
             _ => return Ok(()),
@@ -211,80 +289,23 @@ where
         let c_r: u64 = c_r.into();
 
         // TODO - Improve the performance with a tree rotation
-        if c_r > c_l.saturating_add(1) {
-            // Find the smallest element in `r`, remove it and append to `l`
-            if let Some(leaf) = r.val()?.min_key_leaf()? {
-                r.val_mut()?._remove(leaf.key())?;
+        let left_leaf = l.val_mut()?.max_key_leaf()?;
+        let right_leaf = r.val()?.min_key_leaf()?;
+        match (left_leaf, right_leaf) {
+            (_, Some(leaf)) if c_r > c_l.saturating_add(1) => {
+                r.val_mut()?._remove(leaf._key())?;
                 l.val_mut()?._insert(leaf)?;
             }
-        } else if c_l > c_r.saturating_add(1) {
-            // Find the biggest element in `l`, remove it and append to `r`
-            if let Some(leaf) = l.val()?.max_key_leaf()? {
-                l.val_mut()?._remove(leaf.key())?;
+
+            (Some(leaf), _) if c_l > c_r.saturating_add(1) => {
+                l.val_mut()?._remove(leaf._key())?;
                 r.val_mut()?._insert(leaf)?;
             }
+
+            _ => (),
         }
 
         Ok(())
-    }
-
-    /// Include a key -> value mapping to the set.
-    ///
-    /// If the key was previously mapped, it will return the old value in the form `Ok(Some(V))`.
-    ///
-    /// If the key was not previously mapped, the return will be `Ok(None)`
-    ///
-    /// Internally, a naive balancing will be performed. If the tree contains more elements on the
-    /// left, it will move the maximum key of the left to the right - and vice-versa.
-    pub fn insert(&mut self, k: K, v: V) -> Result<Option<V>, S::Error> {
-        let leaf = Leaf::new(k, v);
-
-        self.balance()?;
-
-        self._insert(leaf)
-    }
-
-    fn _insert(&mut self, leaf: Leaf<K, V>) -> Result<Option<V>, S::Error> {
-        let mut old = None;
-
-        match self {
-            KelvinMap::Empty => *self = KelvinMap::Leaf(leaf),
-
-            KelvinMap::Leaf(l) if l.key() == leaf.key() => {
-                old.replace(l.value().clone());
-                *self = KelvinMap::Leaf(leaf);
-            }
-
-            KelvinMap::Leaf(l) if l.key() < leaf.key() => {
-                let left = Annotated::new(mem::take(self));
-                let right = Annotated::new(KelvinMap::Leaf(leaf));
-
-                *self = KelvinMap::Node(left, right);
-            }
-
-            KelvinMap::Leaf(l) if leaf.key() < l.key() => {
-                let left = Annotated::new(KelvinMap::Leaf(leaf));
-                let right = Annotated::new(mem::take(self));
-
-                *self = KelvinMap::Node(left, right);
-            }
-
-            KelvinMap::Node(l, _)
-                if borrow_max(l.annotation()) >= leaf.key() =>
-            {
-                old = l.val_mut()?._insert(leaf)?;
-            }
-
-            KelvinMap::Node(l, r)
-                if borrow_max(l.annotation()) < leaf.key() =>
-            {
-                old = r.val_mut()?._insert(leaf)?;
-            }
-
-            _ => return Err(InvalidEncoding.into()),
-        }
-
-        Ok(old)
     }
 
     /// Remove a key -> value mapping from the set.
@@ -296,17 +317,17 @@ where
     ///
     /// Internally, a naive balancing will be performed. If the tree contains more elements on the
     /// left, it will move the maximum key of the left to the right - and vice-versa.
-    pub fn remove(&mut self, k: &K) -> Result<Option<V>, S::Error> {
+    pub fn remove(&mut self, k: &K) -> Result<Option<V>, CanonError> {
         self.balance()?;
 
         self._remove(k)
     }
 
-    fn _remove(&mut self, k: &K) -> Result<Option<V>, S::Error> {
+    fn _remove(&mut self, k: &K) -> Result<Option<V>, CanonError> {
         match self {
             KelvinMap::Empty => Ok(None),
 
-            KelvinMap::Leaf(leaf) if leaf.key() == k => {
+            KelvinMap::Leaf(leaf) if leaf._key() == k => {
                 let old = Some(leaf.value().clone());
 
                 *self = KelvinMap::Empty;
@@ -321,7 +342,7 @@ where
                 // If the key is the left child, take its value and move the right child to current
                 // node
                 if let KelvinMap::Leaf(leaf) = &mut *l.val_mut()? {
-                    if leaf.key() == k {
+                    if leaf._key() == k {
                         old.replace(leaf.value().clone());
                     }
                 }
@@ -335,7 +356,7 @@ where
                 // If the key is the right child, take its value and move the left child to current
                 // node
                 if let KelvinMap::Leaf(leaf) = &mut *r.val_mut()? {
-                    if leaf.key() == k {
+                    if leaf._key() == k {
                         old.replace(leaf.value().clone());
                     }
                 }
@@ -346,10 +367,9 @@ where
                     return Ok(old);
                 }
 
-                // Traverse the tree
-                if borrow_max(l.annotation()) >= k {
+                if cmp_max_key(l, k).is_ge() {
                     l.val_mut()?.remove(k)
-                } else if borrow_max(r.annotation()) >= k {
+                } else if cmp_max_key(r, k).is_ge() {
                     r.val_mut()?.remove(k)
                 } else {
                     Ok(None)
@@ -357,62 +377,59 @@ where
             }
         }
     }
-}
 
-/// Private struct used to hide the complex branch signature behind an
-/// `impl Deref<Target = V>` for returning references to values in the map
-struct ValRef<'a, K, V, A, S>(Branch<'a, KelvinMap<K, V, A, S>, S>)
-where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S>,
-    S: Store;
+    /// Include a key -> value mapping to the set.
+    ///
+    /// If the key was previously mapped, it will return the old value in the form `Ok(Some(V))`.
+    ///
+    /// If the key was not previously mapped, the return will be `Ok(None)`
+    ///
+    /// Internally, a naive balancing will be performed. If the tree contains more elements on the
+    /// left, it will move the maximum key of the left to the right - and vice-versa.
+    pub fn insert(&mut self, k: K, v: V) -> Result<Option<V>, CanonError> {
+        let leaf = Leaf::new(k, v);
 
-impl<'a, K, V, A, S> Deref for ValRef<'a, K, V, A, S>
-where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S>,
-    S: Store,
-{
-    type Target = V;
+        self.balance()?;
 
-    fn deref(&self) -> &Self::Target {
-        &**self.0
+        self._insert(leaf)
     }
-}
 
-/// Private struct used to hide the complex branch signature behind an
-/// `impl DerefMut<Target = V>` for returning mutable references to values in the map
-struct ValRefMut<'a, K, V, A, S>(BranchMut<'a, KelvinMap<K, V, A, S>, S>)
-where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S> + Borrow<Max<K>>,
-    S: Store;
+    fn _insert(&mut self, leaf: Leaf<K, V>) -> Result<Option<V>, CanonError> {
+        let mut old = None;
 
-impl<'a, K, V, A, S> Deref for ValRefMut<'a, K, V, A, S>
-where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S> + Borrow<Max<K>>,
-    S: Store,
-{
-    type Target = V;
+        match self {
+            KelvinMap::Empty => *self = KelvinMap::Leaf(leaf),
 
-    fn deref(&self) -> &Self::Target {
-        &**self.0
-    }
-}
+            KelvinMap::Leaf(l) if l._key() == leaf._key() => {
+                old.replace(l.value().clone());
+                *self = KelvinMap::Leaf(leaf);
+            }
 
-impl<'a, K, V, A, S> DerefMut for ValRefMut<'a, K, V, A, S>
-where
-    K: Canon<S> + Ord,
-    V: Canon<S>,
-    A: Canon<S> + Annotation<KelvinMap<K, V, A, S>, S> + Borrow<Max<K>>,
-    S: Store,
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut **self.0
+            KelvinMap::Leaf(l) if l._key() < leaf._key() => {
+                let left = Annotated::new(mem::take(self));
+                let right = Annotated::new(KelvinMap::Leaf(leaf));
+
+                *self = KelvinMap::Node(left, right);
+            }
+
+            KelvinMap::Leaf(l) if leaf._key() < l._key() => {
+                let left = Annotated::new(KelvinMap::Leaf(leaf));
+                let right = Annotated::new(mem::take(self));
+
+                *self = KelvinMap::Node(left, right);
+            }
+
+            KelvinMap::Node(l, _) if cmp_max_key(l, leaf._key()).is_ge() => {
+                old = l.val_mut()?._insert(leaf)?;
+            }
+
+            KelvinMap::Node(l, r) if cmp_max_key(l, leaf._key()).is_lt() => {
+                old = r.val_mut()?._insert(leaf)?;
+            }
+
+            _ => return Err(CanonError::InvalidEncoding),
+        }
+
+        Ok(old)
     }
 }


### PR DESCRIPTION
Canonical 0.6 removes the requirement of store annotation which
facilitates the development an simplifies the annotation.

Resolves: #14